### PR TITLE
Fix CSS IFrame Error

### DIFF
--- a/Q Streaming/index.html
+++ b/Q Streaming/index.html
@@ -23,7 +23,7 @@
 
         iframe {
             width: 100%;
-            height: 0%;
+            height: 80%;
         }
     </style>
 </head>


### PR DESCRIPTION
IFrame `height `was set to `0%` in index.html.
IFrame `height` was changed to `80% `in index.html.