### PR TITLE
Update for Crill dual-camera display CSS

### DIFF
--- a/Q Streaming/index - Copy.html
+++ b/Q Streaming/index - Copy.html
@@ -30,6 +30,9 @@
 
 <body class="grid">
     <div>
+        <h1>T312 (Room 16)</h1><iframe src="http://stats.q2024.org/videos/T312.html"></iframe>
+    </div>
+    <div>
         <h1>T313 (Room 17)</h1><iframe src="http://stats.q2024.org/videos/T313.html"></iframe>
     </div>
     <div>
@@ -62,9 +65,9 @@
     <div>
         <h1>FSB103 (Room 27)</h1><iframe src="http://stats.q2024.org/videos/FSB103.html"></iframe>
     </div>
-    <div>
+    <!-- <div>
         <h1>C101 (Room 28)</h1><iframe src="http://stats.q2024.org/videos/C101.html"></iframe>
-    </div>
+    </div> -->
     <div>
         <h1>FSB105 (Room 29)</h1><iframe src="http://stats.q2024.org/videos/FSB105.html"></iframe>
     </div>

--- a/Q Streaming/index - Copy.html
+++ b/Q Streaming/index - Copy.html
@@ -29,9 +29,9 @@
 </head>
 
 <body class="grid">
-    <div>
+    <!-- <div>
         <h1>T312 (Room 16)</h1><iframe src="http://stats.q2024.org/videos/T312.html"></iframe>
-    </div>
+    </div> -->
     <div>
         <h1>T313 (Room 17)</h1><iframe src="http://stats.q2024.org/videos/T313.html"></iframe>
     </div>

--- a/Q Streaming/index - Copy.html
+++ b/Q Streaming/index - Copy.html
@@ -47,18 +47,18 @@
     <div>
         <h1>R111 (Room 21)</h1><iframe src="http://stats.q2024.org/videos/R111.html"></iframe>
     </div>
-    <div>
+    <!-- <div>
         <h1>R112 (Room 22)</h1><iframe src="http://stats.q2024.org/videos/R112.html"></iframe>
-    </div>
+    </div> -->
     <div>
         <h1>FCC (Room 23)</h1><iframe src="http://stats.q2024.org/videos/FCC.html"></iframe>
     </div>
-    <div>
+    <!-- <div>
         <h1>F201 (Room 24)</h1><iframe src="http://stats.q2024.org/videos/F201.html"></iframe>
-    </div>
-    <div>
+    </div> -->
+    <!-- <div>
         <h1>FSB101 (Room 25)</h1><iframe src="http://stats.q2024.org/videos/FSB101.html"></iframe>
-    </div>
+    </div> -->
     <div>
         <h1>FSB102 (Room 26)</h1><iframe src="http://stats.q2024.org/videos/FSB102.html"></iframe>
     </div>
@@ -68,9 +68,9 @@
     <!-- <div>
         <h1>C101 (Room 28)</h1><iframe src="http://stats.q2024.org/videos/C101.html"></iframe>
     </div> -->
-    <div>
+    <!-- <div>
         <h1>FSB105 (Room 29)</h1><iframe src="http://stats.q2024.org/videos/FSB105.html"></iframe>
-    </div>
+    </div> -->
     <div>
         <h1>FSB109 (Room 30)</h1><iframe src="http://stats.q2024.org/videos/FSB109.html"></iframe>
     </div>

--- a/Q Streaming/index - Copy.html
+++ b/Q Streaming/index - Copy.html
@@ -35,9 +35,9 @@
     <div>
         <h1>T313 (Room 17)</h1><iframe src="http://stats.q2024.org/videos/T313.html"></iframe>
     </div>
-    <div>
+    <!-- <div>
         <h1>T314 (Room 18)</h1><iframe src="http://stats.q2024.org/videos/T314.html"></iframe>
-    </div>
+    </div> -->
     <div>
         <h1>R108 (Room 19)</h1><iframe src="http://stats.q2024.org/videos/R108.html"></iframe>
     </div>

--- a/Q Streaming/index - Copy.html
+++ b/Q Streaming/index - Copy.html
@@ -44,9 +44,9 @@
     <div>
         <h1>R109 (Room 20)</h1><iframe src="http://stats.q2024.org/videos/R109.html"></iframe>
     </div>
-    <div>
+    <!-- <div>
         <h1>R111 (Room 21)</h1><iframe src="http://stats.q2024.org/videos/R111.html"></iframe>
-    </div>
+    </div> -->
     <!-- <div>
         <h1>R112 (Room 22)</h1><iframe src="http://stats.q2024.org/videos/R112.html"></iframe>
     </div> -->

--- a/Q Streaming/index.html
+++ b/Q Streaming/index.html
@@ -66,18 +66,18 @@
     <div>
         <h1>E114 (Room 11)</h1><iframe src="http://stats.q2024.org/videos/E114.html"></iframe>
     </div>
-    <div>
+    <!-- <div>
         <h1>E121 (Room 12)</h1><iframe src="http://stats.q2024.org/videos/E121.html"></iframe>
-    </div>
-    <div>
+    </div> -->
+    <!-- <div>
         <h1>E122 (Room 13)</h1><iframe src="http://stats.q2024.org/videos/E122.html"></iframe>
-    </div>
-    <div>
+    </div> -->
+    <!-- <div>
         <h1>T105 (Room 14)</h1><iframe src="http://stats.q2024.org/videos/T105.html"></iframe>
-    </div>
-    <div>
+    </div> -->
+    <!-- <div>
         <h1>T106 (Room 15)</h1><iframe src="http://stats.q2024.org/videos/T106.html"></iframe>
-    </div>
+    </div> -->
 </body>
 
 </html>

--- a/Q Streaming/index.html
+++ b/Q Streaming/index.html
@@ -15,6 +15,10 @@
             gap: 2px;
         }
 
+        .large-col {
+            grid-column: span 2;
+        }
+
         h1 {
             font-size: 48px;
             margin: 0;
@@ -29,7 +33,7 @@
 </head>
 
 <body class="grid">
-    <div>
+    <div class="large-col">
         <h1>Crill (Room 1)</h1><iframe src="http://stats.q2024.org/videos/Crill.html"></iframe>
     </div>
     <div>
@@ -73,9 +77,6 @@
     </div>
     <div>
         <h1>T106 (Room 15)</h1><iframe src="http://stats.q2024.org/videos/T106.html"></iframe>
-    </div>
-    <div>
-        <h1>T312 (Room 16)</h1><iframe src="http://stats.q2024.org/videos/T312.html"></iframe>
     </div>
 </body>
 

--- a/Q Streaming/index.html
+++ b/Q Streaming/index.html
@@ -60,12 +60,12 @@
     <div>
         <h1>COLTFORM (Room 9)</h1><iframe src="http://stats.q2024.org/videos/COLTFORM.html"></iframe>
     </div>
-    <div>
+    <!-- <div>
         <h1>SB100 (Room 10)</h1><iframe src="http://stats.q2024.org/videos/SB100.html"></iframe>
-    </div>
-    <div>
+    </div> -->
+    <!-- <div>
         <h1>E114 (Room 11)</h1><iframe src="http://stats.q2024.org/videos/E114.html"></iframe>
-    </div>
+    </div> -->
     <!-- <div>
         <h1>E121 (Room 12)</h1><iframe src="http://stats.q2024.org/videos/E121.html"></iframe>
     </div> -->


### PR DESCRIPTION
This change tweaks CSS in `index.html` to show dual-camera spanning the first cell in Room 1 (Crill), and also comments out Room 28 (C101) that should no longer be in use the rest of Q2024 on the right-side `index - Copy.html` file.